### PR TITLE
data loader の num_workers の修正

### DIFF
--- a/lungmask/mask.py
+++ b/lungmask/mask.py
@@ -58,7 +58,7 @@ def apply(image, model=None, force_cpu=False, batch_size=20, volume_postprocessi
         sanity = [(tvolslices[x]>0.6).sum()>25000 for x in range(len(tvolslices))]
         tvolslices = tvolslices[sanity]
     torch_ds_val = utils.LungLabelsDS_inf(tvolslices)
-    dataloader_val = torch.utils.data.DataLoader(torch_ds_val, batch_size=batch_size, shuffle=False, num_workers=1,
+    dataloader_val = torch.utils.data.DataLoader(torch_ds_val, batch_size=batch_size, shuffle=False, num_workers=0,
                                                  pin_memory=False)
 
     timage_res = np.empty((np.append(0, tvolslices[0].shape)), dtype=np.uint8)


### PR DESCRIPTION
* lungmask 内の data loader の num_workers が 1 に設定されていた影響で不要なプロセスが起動する(特に速度が改善しない & メモリ消費が激しくなる)ケースが発生していたため、これを 0 に変更
  * 推論時の速度への影響がないことは確認済み