### PR TITLE
Add apply_async function

### DIFF
--- a/lungmask/mask.py
+++ b/lungmask/mask.py
@@ -65,7 +65,7 @@ def apply_async(image, model=None, force_cpu=False, batch_size=20, volume_postpr
         sanity = [(tvolslices[x]>0.6).sum()>25000 for x in range(len(tvolslices))]
         tvolslices = tvolslices[sanity]
     torch_ds_val = utils.LungLabelsDS_inf(tvolslices)
-    dataloader_val = torch.utils.data.DataLoader(torch_ds_val, batch_size=batch_size, shuffle=False, num_workers=1,
+    dataloader_val = torch.utils.data.DataLoader(torch_ds_val, batch_size=batch_size, shuffle=False, num_workers=0,
                                                  pin_memory=False)
 
     res = []


### PR DESCRIPTION
### Summary of changes
Add `apply_async` function that is without waiting for the asynchronous process of the GPU operation.

### Background

The `apply` function runs an entire operation of lung segmentation. It includes pre-processing, segmentation and post-processing. This means it waits the asynchronous process of GPU operation to receive the result of segmentation. This function works effectively when the input fits into a single batch. But if the input size is large and the input does not fit into a single batch, this function is better to run the next batch without waiting for the asynchronous process of the GPU operation.

### Details of changes
* Add the `MaskAsyncResolver` class for the output of the `apply_async` function.
  * This class has the `resolve` method to wait the asynchronous process of the GPU operation and to run post-processing.
* Add the `apply_async` function that runs until starting the asynchronous process of the GPU operation.
* Modify the `apply` function for using the `apply_async` function.
